### PR TITLE
Add Google Analytics integration with measurement ID

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css';
 import Link from 'next/link';
 import { Analytics } from '@vercel/analytics/react';
 import QueryProvider from '../components/QueryProvider';
+import GoogleAnalytics from '../components/GoogleAnalytics';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -46,8 +47,13 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const googleAnalyticsId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+
   return (
     <html lang='en'>
+      <head>
+        {googleAnalyticsId && <GoogleAnalytics measurementId={googleAnalyticsId} />}
+      </head>
       <body className={inter.className}>
         <QueryProvider>
           <Navigation />

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import Script from 'next/script';
+
+interface GoogleAnalyticsProps {
+  measurementId: string;
+}
+
+export default function GoogleAnalytics({ measurementId }: GoogleAnalyticsProps) {
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${measurementId}');
+        `}
+      </Script>
+    </>
+  );
+}


### PR DESCRIPTION
- Create GoogleAnalytics component with proper Next.js Script optimization
- Add Google Analytics to layout with conditional rendering
- Configure with measurement ID: G-J9NJT60HYC
- Uses afterInteractive strategy for optimal performance
- Works alongside existing Vercel Analytics
