### PR TITLE
Revert to simple Google Maps implementation that was working

### DIFF
--- a/src/components/RouteMapWithTiles.tsx
+++ b/src/components/RouteMapWithTiles.tsx
@@ -71,7 +71,7 @@ export const RouteMapWithTiles: React.FC<RouteMapProps> = ({ flights, className 
   const [mapLoaded, setMapLoaded] = useState(false);
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<google.maps.Map | null>(null);
-  const overlaysRef = useRef<(google.maps.Polyline | google.maps.Marker | any)[]>([]);
+  const overlaysRef = useRef<(google.maps.Polyline | google.maps.Marker)[]>([]);
 
   useEffect(() => {
     setIsClient(true);
@@ -129,7 +129,7 @@ export const RouteMapWithTiles: React.FC<RouteMapProps> = ({ flights, className 
         const script = document.createElement('script');
         // Use environment variable for API key, fallback to a placeholder
         const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || 'YOUR_API_KEY_HERE';
-        script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=marker&loading=async&callback=initGoogleMaps`;
+        script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=geometry&loading=async&callback=initGoogleMaps`;
         script.async = true;
         script.defer = true;
         
@@ -178,12 +178,11 @@ export const RouteMapWithTiles: React.FC<RouteMapProps> = ({ flights, className 
 
         console.log('Creating Google Map with center:', center);
 
-        // Create map with safe options
+        // Create map with basic options (no mapId needed for classic markers)
         const map = new window.google.maps.Map(mapRef.current, {
           zoom: 6,
           center: center,
-          mapTypeId: 'terrain', // Use string instead of enum to avoid undefined issues
-          mapId: 'DEMO_MAP_ID', // Required for AdvancedMarkerElement
+          mapTypeId: 'terrain',
           styles: [], // Clean styling
         });
 
@@ -215,12 +214,8 @@ export const RouteMapWithTiles: React.FC<RouteMapProps> = ({ flights, className 
     try {
       // Clear existing overlays
       overlaysRef.current.forEach(overlay => {
-        if (overlay instanceof google.maps.Polyline) {
+        if (overlay.setMap) {
           overlay.setMap(null);
-        } else if (overlay instanceof google.maps.Marker) {
-          overlay.setMap(null);
-        } else if (window.google.maps.marker && overlay instanceof window.google.maps.marker.AdvancedMarkerElement) {
-          overlay.map = null;
         }
       });
       overlaysRef.current = [];
@@ -256,37 +251,6 @@ export const RouteMapWithTiles: React.FC<RouteMapProps> = ({ flights, className 
         });
 
         overlaysRef.current.push(flightPath);
-
-        // Add flight sequence marker at midpoint
-        const midLat = (origin.lat + destination.lat) / 2;
-        const midLng = (origin.lng + destination.lng) / 2;
-        
-        const sequenceElement = document.createElement('div');
-        sequenceElement.style.cssText = `
-          width: 20px;
-          height: 20px;
-          background-color: #ffffff;
-          border: 2px solid #2563eb;
-          border-radius: 50%;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          font-size: 11px;
-          font-weight: bold;
-          color: #2563eb;
-          box-shadow: 0 2px 4px rgba(0,0,0,0.3);
-        `;
-        sequenceElement.textContent = (index + 1).toString();
-        
-        if (window.google.maps.marker?.AdvancedMarkerElement) {
-          const sequenceMarker = new window.google.maps.marker.AdvancedMarkerElement({
-            position: { lat: midLat, lng: midLng },
-            map: map,
-            title: `Flight ${index + 1}: ${flight.Origin} → ${flight.Destination}`,
-            content: sequenceElement
-          });
-          overlaysRef.current.push(sequenceMarker);
-        }
       });
 
       // Add airport markers
@@ -313,87 +277,26 @@ export const RouteMapWithTiles: React.FC<RouteMapProps> = ({ flights, className 
           markerColor = '#f44336'; // Red for end
         }
 
-        // Debug: Check what's available
-        console.log('Google Maps API availability:', {
-          google: !!window.google,
-          maps: !!window.google?.maps,
-          marker: !!window.google?.maps?.marker,
-          AdvancedMarkerElement: !!window.google?.maps?.marker?.AdvancedMarkerElement,
-          PinElement: !!window.google?.maps?.marker?.PinElement
-        });
-
-        // Use AdvancedMarkerElement when available
-        let marker;
-        if (window.google.maps.marker?.AdvancedMarkerElement) {
-          console.log('Using AdvancedMarkerElement for', airportCode);
-          
-          // Try using PinElement first (newer approach)
-          if (window.google.maps.marker.PinElement) {
-            const pinElement = new window.google.maps.marker.PinElement({
-              background: markerColor,
-              borderColor: 'white',
-              glyphColor: 'white',
-              glyph: airportCode,
-              scale: 0.8 // Smaller scale to reduce overlap
-            });
-            
-            marker = new window.google.maps.marker.AdvancedMarkerElement({
-              position: { lat: airport.lat, lng: airport.lng },
-              map: map,
-              title: `${airportCode} - ${airport.city}`,
-              content: pinElement.element
-            });
-          } else {
-            // Fallback to custom HTML element
-            const pinElement = document.createElement('div');
-            pinElement.style.cssText = `
-              width: 24px;
-              height: 24px;
-              background-color: ${markerColor};
-              border: 2px solid white;
-              border-radius: 50%;
-              display: flex;
-              align-items: center;
-              justify-content: center;
-              font-size: 9px;
-              font-weight: bold;
-              color: white;
-              box-shadow: 0 2px 4px rgba(0,0,0,0.3);
-              cursor: pointer;
-              z-index: 1000;
-            `;
-            pinElement.textContent = airportCode;
-            
-            marker = new window.google.maps.marker.AdvancedMarkerElement({
-              position: { lat: airport.lat, lng: airport.lng },
-              map: map,
-              title: `${airportCode} - ${airport.city}`,
-              content: pinElement
-            });
+        // Use classic Google Maps Marker (simple and reliable)
+        const marker = new window.google.maps.Marker({
+          position: { lat: airport.lat, lng: airport.lng },
+          map: map,
+          title: `${airportCode} - ${airport.city}`,
+          icon: {
+            path: 'M 0, 0 m -5, 0 a 5,5 0 1,0 10,0 a 5,5 0 1,0 -10,0',
+            scale: 1.2,
+            fillColor: markerColor,
+            fillOpacity: 1,
+            strokeColor: 'white',
+            strokeWeight: 2
+          },
+          label: {
+            text: airportCode,
+            color: 'white',
+            fontSize: '11px',
+            fontWeight: 'bold'
           }
-        } else {
-          console.log('Falling back to classic Marker for', airportCode);
-          // Fallback to classic Marker (this is what's causing the deprecation warning)
-          marker = new window.google.maps.Marker({
-            position: { lat: airport.lat, lng: airport.lng },
-            map: map,
-            title: `${airportCode} - ${airport.city}`,
-            icon: {
-              path: 'M 0, 0 m -5, 0 a 5,5 0 1,0 10,0 a 5,5 0 1,0 -10,0',
-              scale: 1.5,
-              fillColor: markerColor,
-              fillOpacity: 1,
-              strokeColor: 'white',
-              strokeWeight: 2
-            },
-            label: {
-              text: airportCode,
-              color: 'white',
-              fontSize: '12px',
-              fontWeight: 'bold'
-            }
-          });
-        }
+        });
 
         overlaysRef.current.push(marker);
       });
@@ -479,10 +382,6 @@ export const RouteMapWithTiles: React.FC<RouteMapProps> = ({ flights, className 
             <div className="flex items-center">
               <div className="w-6 h-0 border-2 border-blue-600 mr-2"></div>
               <span>Flight Path</span>
-            </div>
-            <div className="flex items-center">
-              <div className="w-4 h-4 bg-white border-2 border-blue-600 rounded-full mr-2 flex items-center justify-center text-xs font-bold text-blue-600">1</div>
-              <span>Flight Sequence</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
- Remove all AdvancedMarkerElement code and complexity
- Go back to classic google.maps.Marker (simple and reliable)
- Remove Map ID requirement and marker library loading
- Remove sequence markers and advanced features that were causing issues
- Simplified overlay cleanup logic
- Use geometry library only (standard Google Maps setup)

This should restore the working map functionality on production.

